### PR TITLE
bugfixes in whackaspam

### DIFF
--- a/client/components/Games/WhackASpam.tsx
+++ b/client/components/Games/WhackASpam.tsx
@@ -33,7 +33,7 @@ function WhackASpam() {
   }, [timer])
 
   function chooseRandomCell() {
-    let randomCell = getRandomNumber(0, 16)
+    const randomCell = getRandomNumber(0, 15)
     setSelectedCell(randomCell)
   }
 

--- a/client/components/UI/Table.tsx
+++ b/client/components/UI/Table.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 interface Props {
   selectedCell: null | number
   image: string
@@ -15,7 +17,7 @@ function Table({ selectedCell, image, whackThatSpam }: Props) {
         : '',
     ),
   )
-
+console.log({selectedCell})
   return (
     <table
       style={{
@@ -42,8 +44,9 @@ function Table({ selectedCell, image, whackThatSpam }: Props) {
               >
                 {cell == image ? (
                   <img
+                    draggable={false}
                     src={`${image}`}
-                    alt={'picture of a spam'}
+                    alt={'a can of spam'}
                     onClick={whackThatSpam}
                     role="button"
                   />


### PR DESCRIPTION
- changed random range to 0-15, as cell 16 doesn't exist in table so spam can would momentarily disappear
- added dragable=false attribute to the spam can to stop accidental drags